### PR TITLE
fix(render): fix references to have rendering succeed

### DIFF
--- a/CustomTables.php
+++ b/CustomTables.php
@@ -316,7 +316,7 @@ add_shortcode('customtables', function($form_attributes) {
     }
 
     if (isset($attributes['view']) and !empty($attributes['view'])) {
-        if ($attributes['view'] != 'edit' and $attributes['view'] != 'details' and $attributes['view'] == 'catalog')
+        if ($attributes['view'] != 'edit' and $attributes['view'] != 'details' and $attributes['view'] != 'catalog')
             return 'Error: "view" parameter can be "edititem" or "details" or "catalog")';
     }
 

--- a/build/template.php
+++ b/build/template.php
@@ -210,7 +210,7 @@ class template
 			}
 		}
 
-		$mixedLayout_safe = $mixedLayout_array['html'] ?? null;
+		$mixedLayout_safe = $mixedLayout_array['content'] ?? null;
 		$this->enqueueList['FieldInputPrefix'] = $ct->Table->fieldInputPrefix;
 
 		$message = get_transient('customtables_error_message');


### PR DESCRIPTION
This plugin was failing completely on my instance.

1. There's an invalid logic for the `view` parameter for the shortcode.
2. The reference to the `html` vs `content` key appeared incorrect, so I updated it. The `content` key appears correct.